### PR TITLE
IP Report Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ $ npm run start:prod
 
 ## Testing multiple child_process
 
-- Open file and change the variables for retry attempt and delay time.
+- If you want to change the variables for retry attempts and delay time of workers update the `report.service.ts` file under the report module.
 
-- Run the application
+- Run the application:
 
 ```bash
 $ npm run start
@@ -56,20 +56,25 @@ $ npm run start
 ```
 
 - Open the Activity Monitor of your operative system.
+  <img width="1385" alt="Screen Shot 2020-10-30 at 12 35 07 PM" src="https://user-images.githubusercontent.com/2147281/97745412-71c06d00-1aae-11eb-95de-4f59109dedbb.png">
 
-- -Run the following cURL instruccion to make a POST call to generate a new IP report.
+- Run the following cURL instruction to make a POST call to generate a new IP report.
 
 ```bash
 $ curl -d '{"ip": "8.8.8.8","reportServices": ["ipapi", "freegeoip"]}' -H "Content-Type: application/json" -X POST http://localhost:3000/generateMultipleIpReport
 
 ```
 
-- Notice that for each report system will create a new node child process to execute the task and then it will terminate the process.
+<img width="1424" alt="Screen Shot 2020-10-30 at 12 36 20 PM" src="https://user-images.githubusercontent.com/2147281/97745541-a2a0a200-1aae-11eb-86ae-62ff9e84d2fe.png">
+
+- Notice that for each report the system will create a new node child process to execute the task and then it will terminate the process.
 
 ```bash
 $ curl -d '{"ip": "8.8.8.8","reportServices": ["ipapi", "freegeoip", "ipapi", "freegeoip", "ipapi", "freegeoip"]}' -H "Content-Type: application/json" -X POST http://localhost:3000/generateMultipleIpReport
 
 ```
+
+<img width="1390" alt="Screen Shot 2020-10-30 at 12 39 40 PM" src="https://user-images.githubusercontent.com/2147281/97745510-987ea380-1aae-11eb-80fe-fbaea39153a3.png">
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
 ## Description
 
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+It provides a simple example of the implementation of node child_process API as server workers using the observable pattern with RxJS.
+
+You also can use this example as a reference for:
+
+- To understand how to implement RxJS on the server-side. 🚀
+- To understand how to create a new node child process and communicate with them using observable patter.
+- A basic architecture to implement nestJS at enterprise-level applications.
+
+## Project Structure Overview
+
+```
+    -- root
+        -- src
+            -- modules
+                --  app
+                    --  app.controller.ts // It contains the main route and service status route.
+                    --  app.module.ts // Main application module.
+                -- report
+                    -- report.controller.ts // it contains the POST /generateMultipleIpReport controller to generate the reports.
+                    -- report.module.ts
+                    -- report.service.ts // it contains the worker launcher and communication. Also, it provides PROCESS_DELAY and MAX_ATTEMPTS variables configuration.
+                    -- report.worker.ts // it contains the code that will be executed in the child node.
+            -- main.ts // Application entry point.
+```
 
 ## Installation
 
@@ -19,6 +42,33 @@ $ npm run start:dev
 
 # production mode
 $ npm run start:prod
+```
+
+## Testing multiple child_process
+
+- Open file and change the variables for retry attempt and delay time.
+
+- Run the application
+
+```bash
+$ npm run start
+
+```
+
+- Open the Activity Monitor of your operative system.
+
+- -Run the following cURL instruccion to make a POST call to generate a new IP report.
+
+```bash
+$ curl -d '{"ip": "8.8.8.8","reportServices": ["ipapi", "freegeoip"]}' -H "Content-Type: application/json" -X POST http://localhost:3000/generateMultipleIpReport
+
+```
+
+- Notice that for each report system will create a new node child process to execute the task and then it will terminate the process.
+
+```bash
+$ curl -d '{"ip": "8.8.8.8","reportServices": ["ipapi", "freegeoip", "ipapi", "freegeoip", "ipapi", "freegeoip"]}' -H "Content-Type: application/json" -X POST http://localhost:3000/generateMultipleIpReport
+
 ```
 
 ## Test
@@ -40,10 +90,9 @@ Nest is an MIT-licensed open source project. It can grow thanks to the sponsors 
 
 ## Stay in touch
 
-- Author - [Kamil Myśliwiec](https://kamilmysliwiec.com)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
+- Author - [Bryan Ramirez](https://github.com/brq-cr)
+- Framework Website - [https://nestjs.com](https://nestjs.com/)
 
 ## License
 
-Nest is [MIT licensed](LICENSE).
+Nest framework and the code of this exercise are [MIT licensed](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# nest-queues-example
-It provides a simple example of using queues feature in nest js framework
+## Description
+
+[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+
+## Installation
+
+```bash
+$ npm install
+```
+
+## Running the app
+
+```bash
+# development
+$ npm run start
+
+# watch mode
+$ npm run start:dev
+
+# production mode
+$ npm run start:prod
+```
+
+## Test
+
+```bash
+# unit tests
+$ npm run test
+
+# e2e tests
+$ npm run test:e2e
+
+# test coverage
+$ npm run test:cov
+```
+
+## Support
+
+Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
+
+## Stay in touch
+
+- Author - [Kamil Myśliwiec](https://kamilmysliwiec.com)
+- Website - [https://nestjs.com](https://nestjs.com/)
+- Twitter - [@nestframework](https://twitter.com/nestframework)
+
+## License
+
+Nest is [MIT licensed](LICENSE).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ npm run start:dev
 $ npm run start:prod
 ```
 
-## Testing multiple child_process
+## Testing multiple child_process feature
 
 - If you want to change the variables for retry attempts and delay time of workers update the `report.service.ts` file under the report module.
 

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "queues-example",
+  "version": "0.0.1",
+  "description": "Just an example of using NestJs with queues",
+  "author": "Bryan Ramirez",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "prebuild": "rimraf dist",
+    "build": "nest build",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:debug": "nest start --debug --watch",
+    "start:prod": "node dist/main",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:e2e": "jest --config ./test/jest-e2e.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^7.0.0",
+    "@nestjs/core": "^7.0.0",
+    "@nestjs/platform-express": "^7.0.0",
+    "axios": "^0.21.0",
+    "reflect-metadata": "^0.1.13",
+    "rimraf": "^3.0.2",
+    "rxjs": "^6.5.4"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^7.0.0",
+    "@nestjs/schematics": "^7.0.0",
+    "@nestjs/testing": "^7.0.0",
+    "@types/express": "^4.17.3",
+    "@types/jest": "26.0.10",
+    "@types/node": "^13.9.1",
+    "@types/supertest": "^2.0.8",
+    "@typescript-eslint/eslint-plugin": "3.9.1",
+    "@typescript-eslint/parser": "3.9.1",
+    "eslint": "7.7.0",
+    "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-import": "^2.20.1",
+    "jest": "26.4.2",
+    "prettier": "^1.19.1",
+    "supertest": "^4.0.2",
+    "ts-jest": "26.2.0",
+    "ts-loader": "^6.2.1",
+    "ts-node": "9.0.0",
+    "tsconfig-paths": "^3.9.0",
+    "tslint": "^6.1.3",
+    "tslint-config-prettier": "^1.18.0",
+    "tslint-config-airbnb": "^5.11.2",
+    "typescript": "^3.7.4"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": "src",
+    "testRegex": ".spec.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint": "tslint --project tsconfig.json",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@nestjs/core": "^7.0.0",
     "@nestjs/platform-express": "^7.0.0",
     "axios": "^0.21.0",
+    "class-transformer": "^0.3.1",
+    "class-validator": "^0.12.2",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^6.5.4"

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
     "@nestjs/common": "^7.0.0",
     "@nestjs/core": "^7.0.0",
     "@nestjs/platform-express": "^7.0.0",
+    "@nestjs/swagger": "^4.6.1",
     "axios": "^0.21.0",
     "class-transformer": "^0.3.1",
     "class-validator": "^0.12.2",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
-    "rxjs": "^6.5.4"
+    "rxjs": "^6.5.4",
+    "swagger-ui-express": "^4.1.4"
   },
   "devDependencies": {
     "@nestjs/cli": "^7.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './modules/app/app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,21 @@
 import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder } from '@nestjs/swagger/dist/document-builder';
+import { SwaggerModule } from '@nestjs/swagger/dist/swagger-module';
 import { AppModule } from './modules/app/app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const options = new DocumentBuilder()
+    .setTitle('NestJS RxJS workers example')
+    .setDescription(
+      'It provides a simple example of using node child_process API to run async code in parallel by running IP region reports',
+    )
+    .setVersion('1.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, options);
+  SwaggerModule.setup('api', app, document);
+
   await app.listen(3000);
 }
 bootstrap();

--- a/src/modules/app/app.controller.spec.ts
+++ b/src/modules/app/app.controller.spec.ts
@@ -1,0 +1,21 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppController } from './app.controller';
+
+describe('AppController', () => {
+  let appController: AppController;
+
+  beforeEach(async () => {
+    const app: TestingModule = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [],
+    }).compile();
+
+    appController = app.get<AppController>(AppController);
+  });
+
+  describe('root', () => {
+    it('should return "System is up and running."', () => {
+      expect(appController.getSystemStatus()).toBe('System is up and running.');
+    });
+  });
+});

--- a/src/modules/app/app.controller.ts
+++ b/src/modules/app/app.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
 
 @Controller()
 export class AppController {
@@ -10,6 +11,7 @@ export class AppController {
   }
 
   @Get('status')
+  @ApiOperation({ summary: 'Use this endpoint to check if server is running' })
   getSystemStatus(): string {
     return 'System is up and running.';
   }

--- a/src/modules/app/app.controller.ts
+++ b/src/modules/app/app.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class AppController {
+  constructor() {}
+
+  @Get('')
+  getSystemInformation(): string {
+    return 'Please visit https://github.com/brq-cr/nestjs-rx-workers-poc for more information about this application.';
+  }
+
+  @Get('status')
+  getSystemStatus(): string {
+    return 'System is up and running.';
+  }
+}

--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { ReportModule } from './../report/report.module';
+
+
+@Module({
+  imports: [ReportModule],
+  controllers: [AppController],
+})
+export class AppModule {}

--- a/src/modules/report/report.controller.spec.ts
+++ b/src/modules/report/report.controller.spec.ts
@@ -1,0 +1,53 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { generate, of } from 'rxjs';
+import { ReportController } from './report.controller';
+import { ReportDto } from './report.dto';
+import { ReportService } from './report.service';
+import { Report } from './report.transformer';
+import { IPReport, IPReportServices } from './report.types';
+
+describe('reportController', () => {
+  let reportController: ReportController;
+  let reportService: ReportService;
+
+  beforeEach(async () => {
+    const reportModule: TestingModule = await Test.createTestingModule({
+      controllers: [ReportController],
+      providers: [ReportService],
+    }).compile();
+
+    reportController = reportModule.get<ReportController>(ReportController);
+    reportService = reportModule.get<ReportService>(ReportService);
+  });
+
+  describe('Generate Multiple Ip Report', () => {
+    it('should return a list of reports', done => {
+      const reportsReponse: IPReport[] = [
+        {
+          reportService: IPReportServices.Ipapi,
+          data: {
+            ip: '8.8.8.8',
+            countryName: 'United States',
+            countryCode: 'USA',
+            regionCode: 'MR',
+          },
+        },
+      ];
+      const reportsControllerResult: Report[] = reportsReponse.map(
+        report => new Report(report),
+      );
+      const reportInput: ReportDto = {
+        ip: '8.8.8.8',
+        reportServices: [IPReportServices.Ipapi],
+      };
+      const reportSpy = jest
+        .spyOn(reportService, 'generateMultipleReport')
+        .mockImplementation(() => of(reportsReponse));
+      reportController.generateMultipleIpReport(reportInput).subscribe(data => {
+        expect(data).toStrictEqual(reportsControllerResult);
+        expect(reportSpy).toBeCalledTimes(1);
+        done();
+      });
+    });
+  });
+});

--- a/src/modules/report/report.controller.spec.ts
+++ b/src/modules/report/report.controller.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { generate, of } from 'rxjs';
+import { of } from 'rxjs';
 import { ReportController } from './report.controller';
 import { ReportDto } from './report.dto';
 import { ReportService } from './report.service';

--- a/src/modules/report/report.controller.ts
+++ b/src/modules/report/report.controller.ts
@@ -1,13 +1,17 @@
 import {
   Body,
+  ClassSerializerInterceptor,
   Controller,
   Post,
+  UseInterceptors,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
-import { Observable } from 'rxjs';
+import { from, Observable } from 'rxjs';
+import { switchMap, toArray, map } from 'rxjs/operators';
 import { ReportDto } from './report.dto';
 import { ReportService } from './report.service';
+import { Report } from './report.transformer';
 import { IPReport } from './report.types';
 
 @Controller()
@@ -15,12 +19,19 @@ export class ReportController {
   constructor(private reportService: ReportService) {}
 
   // RPC (Remote Procedure Call) is prefered over REST due we are calling a procedure instead of a entity maintenance (CRUD)
+  @UseInterceptors(ClassSerializerInterceptor)
   @Post('generateMultipleIpReport')
   @UsePipes(new ValidationPipe({ transform: true }))
-  generateMultipleIpReport(@Body() report: ReportDto): Observable<IPReport[]> {
-    return this.reportService.generateMultipleReport(
-      report.ip,
-      report.reportServices,
-    );
+  generateMultipleIpReport(@Body() report: ReportDto): Observable<Report[]> {
+    return this.reportService
+      .generateMultipleReport(report.ip, report.reportServices)
+      .pipe(
+        switchMap(ipReports =>
+          from(ipReports).pipe(
+            map(ipReport => new Report(ipReport)),
+            toArray(),
+          ),
+        ),
+      );
   }
 }

--- a/src/modules/report/report.controller.ts
+++ b/src/modules/report/report.controller.ts
@@ -7,13 +7,14 @@ import {
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { from, Observable } from 'rxjs';
-import { switchMap, toArray, map } from 'rxjs/operators';
+import { toArray, map, concatMap } from 'rxjs/operators';
 import { ReportDto } from './report.dto';
 import { ReportService } from './report.service';
 import { Report } from './report.transformer';
-import { IPReport } from './report.types';
 
+@ApiTags('reports')
 @Controller()
 export class ReportController {
   constructor(private reportService: ReportService) {}
@@ -21,12 +22,18 @@ export class ReportController {
   // RPC (Remote Procedure Call) is prefered over REST due we are calling a procedure instead of a entity maintenance (CRUD)
   @UseInterceptors(ClassSerializerInterceptor)
   @Post('generateMultipleIpReport')
+  @ApiOperation({ summary: 'Generate Multtiple IP Report' })
+  @ApiResponse({
+    status: 201,
+    description: 'The report has been successfully generated.',
+    type: [Report],
+  })
   @UsePipes(new ValidationPipe({ transform: true }))
   generateMultipleIpReport(@Body() report: ReportDto): Observable<Report[]> {
     return this.reportService
       .generateMultipleReport(report.ip, report.reportServices)
       .pipe(
-        switchMap(ipReports =>
+        concatMap(ipReports =>
           from(ipReports).pipe(
             map(ipReport => new Report(ipReport)),
             toArray(),

--- a/src/modules/report/report.controller.ts
+++ b/src/modules/report/report.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { ReportService } from './report.service';
+import { IPReport, IPReportServices } from './report.types';
+
+@Controller()
+export class ReportController {
+  constructor(private reportService: ReportService) {}
+
+  // RPC (Remote Procedure Call) is prefered over REST due we are calling a procedure
+  @Get('generateMultipleIpReport')
+  generateMultipleIpReport(): Observable<IPReport[]> {
+    return this.reportService.generateMultipleReport('8.8.8.8', [
+      IPReportServices.Ipapi,
+      IPReportServices.Freegeoip,
+    ]);
+  }
+}

--- a/src/modules/report/report.controller.ts
+++ b/src/modules/report/report.controller.ts
@@ -1,18 +1,26 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
 import { Observable } from 'rxjs';
+import { ReportDto } from './report.dto';
 import { ReportService } from './report.service';
-import { IPReport, IPReportServices } from './report.types';
+import { IPReport } from './report.types';
 
 @Controller()
 export class ReportController {
   constructor(private reportService: ReportService) {}
 
-  // RPC (Remote Procedure Call) is prefered over REST due we are calling a procedure
-  @Get('generateMultipleIpReport')
-  generateMultipleIpReport(): Observable<IPReport[]> {
-    return this.reportService.generateMultipleReport('8.8.8.8', [
-      IPReportServices.Ipapi,
-      IPReportServices.Freegeoip,
-    ]);
+  // RPC (Remote Procedure Call) is prefered over REST due we are calling a procedure instead of a entity maintenance (CRUD)
+  @Post('generateMultipleIpReport')
+  @UsePipes(new ValidationPipe({ transform: true }))
+  generateMultipleIpReport(@Body() report: ReportDto): Observable<IPReport[]> {
+    return this.reportService.generateMultipleReport(
+      report.ip,
+      report.reportServices,
+    );
   }
 }

--- a/src/modules/report/report.dto.ts
+++ b/src/modules/report/report.dto.ts
@@ -1,10 +1,18 @@
 import { IsIP, IsNotEmpty } from 'class-validator';
 import { IPReportServices } from './report.types';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ReportDto {
+  @ApiProperty({ example: '8.8.8.8', description: 'IP v4 to build report' })
   @IsIP('4')
   ip: string;
 
+  @ApiPropertyOptional()
+  @ApiProperty({
+    description: 'IP report services',
+    example: [IPReportServices.Freegeoip, IPReportServices.Ipapi],
+    type: [String],
+  })
   @IsNotEmpty()
   reportServices: IPReportServices[] = [
     IPReportServices.Freegeoip,

--- a/src/modules/report/report.dto.ts
+++ b/src/modules/report/report.dto.ts
@@ -1,0 +1,13 @@
+import { IsIP, IsNotEmpty } from 'class-validator';
+import { IPReportServices } from './report.types';
+
+export class ReportDto {
+  @IsIP('4')
+  ip: string;
+
+  @IsNotEmpty()
+  reportServices: IPReportServices[] = [
+    IPReportServices.Freegeoip,
+    IPReportServices.Ipapi,
+  ];
+}

--- a/src/modules/report/report.module.ts
+++ b/src/modules/report/report.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ReportController } from './report.controller';
+import { ReportService } from './report.service';
+
+@Module({
+  controllers: [ReportController],
+  providers: [ReportService],
+})
+export class ReportModule {}

--- a/src/modules/report/report.service.ts
+++ b/src/modules/report/report.service.ts
@@ -65,7 +65,7 @@ export class ReportService {
             ip: response.ip,
             countryCode: response.country_code,
             countryName: response.country_name,
-            regionName: response.country_name,
+            regionCode: response.region_code,
           },
         });
       });

--- a/src/modules/report/report.service.ts
+++ b/src/modules/report/report.service.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@nestjs/common';
+import { Observable, from } from 'rxjs';
+import { toArray, mergeMap } from 'rxjs/operators';
+import { IPReport, IPReportServices, IPReportServiceURL } from './report.types';
+import { fork } from 'child_process';
+import { ReportResponse } from './report.worker';
+
+const PROCESS_DELAY = 5000;
+const MAX_ATTEMPTS = 2;
+
+@Injectable()
+export class ReportService {
+  public generateMultipleReport(
+    ip: string,
+    ipReportServices: IPReportServices[],
+  ): Observable<IPReport[]> {
+    return from(ipReportServices).pipe(
+      mergeMap(ipReportService =>
+        this.generateIPReport(
+          ip,
+          ipReportService,
+          this.getReportServiceUrl(ipReportService),
+          MAX_ATTEMPTS,
+        ),
+      ),
+      toArray(),
+    );
+  }
+
+  private getReportServiceUrl(
+    reportService: IPReportServices,
+  ): IPReportServiceURL {
+    switch (reportService) {
+      case IPReportServices.Freegeoip:
+        return IPReportServiceURL.Freegeoip;
+      case IPReportServices.Ipapi:
+        return IPReportServiceURL.Ipapi;
+      default:
+        return null;
+    }
+  }
+
+  private generateIPReport(
+    ip: string,
+    reportService: IPReportServices,
+    reportServiceUrl: IPReportServiceURL,
+    retryAttempts: number = 0,
+  ): Observable<IPReport> {
+    return new Observable(observer => {
+      // Since we are using typescript we need to point the
+      // fork module route to our dist folder in order to get the JS file.
+      const worker = fork(
+        './dist/modules/report/report.worker.js',
+        [
+          reportServiceUrl.replace('{ip}', ip),
+          PROCESS_DELAY.toString(),
+          retryAttempts.toString(),
+        ],
+        {},
+      );
+      worker.on('message', (response: ReportResponse) => {
+        observer.next({
+          reportService,
+          data: {
+            ip: response.ip,
+            countryCode: response.country_code,
+            countryName: response.country_name,
+            regionName: response.country_name,
+          },
+        });
+      });
+      worker.on('exit', e => {
+        if (e) {
+          observer.next({
+            reportService,
+            data: null,
+          });
+        }
+        observer.complete();
+      });
+      worker.on('error', e => {
+        observer.error(e);
+      });
+    });
+  }
+}

--- a/src/modules/report/report.transformer.ts
+++ b/src/modules/report/report.transformer.ts
@@ -1,0 +1,19 @@
+import { Exclude } from 'class-transformer';
+import { IPReport } from './report.types';
+
+export class Report {
+  reportService: string;
+  countryCode: string;
+  countryName: string;
+  regionName: string;
+
+  @Exclude()
+  ip: string;
+
+  constructor(partial: Partial<IPReport>) {
+    Object.assign(this, {
+      ...partial.data,
+      reportService: partial.reportService,
+    });
+  }
+}

--- a/src/modules/report/report.transformer.ts
+++ b/src/modules/report/report.transformer.ts
@@ -1,11 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Exclude } from 'class-transformer';
 import { IPReport } from './report.types';
 
 export class Report {
+  @ApiProperty({ example: 'ipapi', description: 'Ip Report source' })
   reportService: string;
+
+  @ApiProperty({ example: 'US', description: 'Ip Country Code' })
   countryCode: string;
+
+  @ApiProperty({ example: 'United States', description: 'IP Country Name' })
   countryName: string;
-  regionName: string;
+
+  @ApiProperty({ example: 'CA', description: 'IP Region Code' })
+  regionCode: string;
 
   @Exclude()
   ip: string;

--- a/src/modules/report/report.types.ts
+++ b/src/modules/report/report.types.ts
@@ -9,7 +9,7 @@ export type IPReport = {
     ip: string;
     countryCode: string;
     countryName: string;
-    regionName: string;
+    regionCode: string;
   };
 };
 

--- a/src/modules/report/report.types.ts
+++ b/src/modules/report/report.types.ts
@@ -1,0 +1,19 @@
+export enum IPReportServices {
+  Freegeoip = 'freegeoip',
+  Ipapi = 'ipapi',
+}
+
+export type IPReport = {
+  reportService: IPReportServices;
+  data: {
+    ip: string;
+    countryCode: string;
+    countryName: string;
+    regionName: string;
+  };
+};
+
+export enum IPReportServiceURL {
+  Freegeoip = 'https://freegeoip.app/json/{ip}',
+  Ipapi = 'https://ipapi.co/{ip}/json/',
+}

--- a/src/modules/report/report.worker.ts
+++ b/src/modules/report/report.worker.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { from, Subscription, timer } from 'rxjs';
-import { retry, switchMap } from 'rxjs/operators';
+import { retry, concatMap } from 'rxjs/operators';
 
 const [nodeRoute, scriptRoute, url, delay, retryAttempts] = process.argv;
 
@@ -8,12 +8,12 @@ export interface ReportResponse {
   ip: string;
   country_code: string;
   country_name: string;
-  region_name: string;
+  region_code: string;
 }
 
 const request: Subscription = timer(parseFloat(delay) || 0)
   .pipe(
-    switchMap(() => from(axios.get<ReportResponse>(url))),
+    concatMap(() => from(axios.get<ReportResponse>(url))),
     retry(parseFloat(retryAttempts)),
   )
   .subscribe(

--- a/src/modules/report/report.worker.ts
+++ b/src/modules/report/report.worker.ts
@@ -13,8 +13,8 @@ export interface ReportResponse {
 
 const request: Subscription = timer(parseFloat(delay) || 0)
   .pipe(
-    concatMap(() => from(axios.get<ReportResponse>(url))),
-    retry(parseFloat(retryAttempts)),
+    concatMap(() => axios.get<ReportResponse>(url)),
+    retry(parseFloat(retryAttempts) || 0),
   )
   .subscribe(
     result => {

--- a/src/modules/report/report.worker.ts
+++ b/src/modules/report/report.worker.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+import { from, Subscription, timer } from 'rxjs';
+import { retry, switchMap } from 'rxjs/operators';
+
+const [nodeRoute, scriptRoute, url, delay, retryAttempts] = process.argv;
+
+export interface ReportResponse {
+  ip: string;
+  country_code: string;
+  country_name: string;
+  region_name: string;
+}
+
+const request: Subscription = timer(parseFloat(delay) || 0)
+  .pipe(
+    switchMap(() => from(axios.get<ReportResponse>(url))),
+    retry(parseFloat(retryAttempts)),
+  )
+  .subscribe(
+    result => {
+      process.send(result.data);
+      request.unsubscribe();
+      process.exit();
+    },
+    err => {
+      request.unsubscribe();
+      process.exit(1);
+    },
+  );

--- a/src/modules/report/report.worker.ts
+++ b/src/modules/report/report.worker.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { from, Subscription, timer } from 'rxjs';
+import { Subscription, timer } from 'rxjs';
 import { retry, concatMap } from 'rxjs/operators';
 
 const [nodeRoute, scriptRoute, url, delay, retryAttempts] = process.argv;

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -19,6 +19,8 @@ describe('AppController (e2e)', () => {
     return request(app.getHttpServer())
       .get('/')
       .expect(200)
-      .expect('System is up and running.');
+      .expect(
+        'Please visit https://github.com/brq-cr/nestjs-rx-workers-poc for more information about this application.',
+      );
   });
 });

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,0 +1,24 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from './../src/modules/app/app.module';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/ (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect('System is up and running.');
+  });
+});

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,6 @@
+{
+  "defaultSeverity": "error",
+  "extends": ["tslint-config-airbnb", "tslint-config-prettier"],
+  "rules": {},
+  "rulesDirectory": []
+}


### PR DESCRIPTION
**What does this PR do?**

Adds the IP report feature. Each report will run in a separate node child process. 

**How should this be tested?**

- If you want to change the variables for retry attempts and delay time of workers update the `report.service.ts` file under the report module.

- Run the application:

```bash
$ npm run start

```

- Open the Activity Monitor of your operative system.
<img width="1385" alt="Screen Shot 2020-10-30 at 12 35 07 PM" src="https://user-images.githubusercontent.com/2147281/97745412-71c06d00-1aae-11eb-95de-4f59109dedbb.png">


-Run the following cURL instruction to make a POST call to generate a new IP report.

```bash
$ curl -d '{"ip": "8.8.8.8","reportServices": ["ipapi", "freegeoip"]}' -H "Content-Type: application/json" -X POST http://localhost:3000/generateMultipleIpReport

```
<img width="1424" alt="Screen Shot 2020-10-30 at 12 36 20 PM" src="https://user-images.githubusercontent.com/2147281/97745541-a2a0a200-1aae-11eb-86ae-62ff9e84d2fe.png">


- Notice that for each report the system will create a new node child process to execute the task and then it will terminate the process.

```bash
$ curl -d '{"ip": "8.8.8.8","reportServices": ["ipapi", "freegeoip", "ipapi", "freegeoip", "ipapi", "freegeoip"]}' -H "Content-Type: application/json" -X POST http://localhost:3000/generateMultipleIpReport

```
<img width="1390" alt="Screen Shot 2020-10-30 at 12 39 40 PM" src="https://user-images.githubusercontent.com/2147281/97745510-987ea380-1aae-11eb-80fe-fbaea39153a3.png">
